### PR TITLE
v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/ia-dropdown",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/ia-dropdown",
-      "version": "1.4.1",
+      "version": "2.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "lit": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Version removes the `openViaCaret` property, in favor of updated & more accessible behavior:
- When `openViaButton` is true (default), the caret is always an inert presentational icon within the main button
- When `openViaButton` is false, the caret is a separate button outside of the main one, toggling the dropdown state.

Additional missing element attributes are added to improve screen-reader usability, and keyboard focus/activation behavior for the main button & caret are updated to follow best practices.