### PR TITLE
WEBDEV-8279 Update CI to use valid codecov approach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 24.x
 
     - name: Install dependencies
       run: npm install
@@ -22,5 +22,6 @@ jobs:
     - name: Run tests
       run: npm run test
 
-    - name: Upload reports
-      run: npx codecov
+    - uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Builds are failing for this repo because the codecov report upload step is using an outdated setup. This PR updates our CI to upgrade dependencies & upload those reports correctly.