### PR TITLE
WEBDEV-8447 Don't set toggle button z-index when dropdown is closed

### DIFF
--- a/src/ia-dropdown.ts
+++ b/src/ia-dropdown.ts
@@ -478,6 +478,7 @@ export class IaDropdown extends LitElement {
     const dropdownSelectedBgColor = css`var(--dropdownSelectedBgColor, #fff)`;
     const dropdownMainButtonBgColor = css`var(--dropdownMainButtonBgColor, transparent)`;
     const dropdownTextAlign = css`var(--dropdownTextAlign, inherit)`;
+    const dropdownListZIndex = css`var(--dropdownListZIndex, 2)`;
 
     return css`
       :host {
@@ -511,7 +512,13 @@ export class IaDropdown extends LitElement {
         align-content: center;
         flex-wrap: nowrap;
         flex-direction: var(--dropdownMainButtonFlexDirection, row);
-        z-index: var(--dropdownListZIndex, 2);
+      }
+
+      .open button.click-main {
+        /* When the dropdown is open, give the buttom the same z-index
+           as the dropdown menu, so that it remains clickable despite
+           the backdrop. */
+        z-index: ${dropdownListZIndex};
       }
 
       button.click-main:disabled {
@@ -605,7 +612,7 @@ export class IaDropdown extends LitElement {
       }
 
       ul {
-        z-index: var(--dropdownListZIndex, 2);
+        z-index: ${dropdownListZIndex};
       }
 
       #dropdown-main.closed {

--- a/src/ia-dropdown.ts
+++ b/src/ia-dropdown.ts
@@ -478,6 +478,7 @@ export class IaDropdown extends LitElement {
     const dropdownSelectedBgColor = css`var(--dropdownSelectedBgColor, #fff)`;
     const dropdownMainButtonBgColor = css`var(--dropdownMainButtonBgColor, transparent)`;
     const dropdownTextAlign = css`var(--dropdownTextAlign, inherit)`;
+    const dropdownBackdropZIndex = css`var(--dropdownBackdropZIndex, 1)`;
     const dropdownListZIndex = css`var(--dropdownListZIndex, 2)`;
 
     return css`
@@ -608,7 +609,7 @@ export class IaDropdown extends LitElement {
         width: 100vw;
         height: 100vh;
         background-color: transparent;
-        z-index: 1;
+        z-index: ${dropdownBackdropZIndex};
       }
 
       ul {

--- a/src/ia-dropdown.ts
+++ b/src/ia-dropdown.ts
@@ -429,7 +429,7 @@ export class IaDropdown extends LitElement {
 
   render() {
     return html`
-      <div class="ia-dropdown-group">
+      <div class="ia-dropdown-group ${this.open ? 'open' : ''}">
         <div class="button-row">
           <button
             class="click-main"


### PR DESCRIPTION
Currently the z-index of the dropdown's main toggle button is always set to the same value as the dropdown menu, even when the dropdown is closed. This leads to strange behavior where the button can appear atop other elements that should reasonably be behind the dropdown menu when it's open, but make little sense being behind the button. Seemingly the z-index was originally added to the button so that it remains clickable over the backdrop when the dropdown is open, so this PR just ensures it only receives that z-index when the dropdown is open rather than all the time. The backdrop z-index is also made customizable via CSS var so that consumers can adjust both as required by the use case.