### PR TITLE
v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/ia-dropdown",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/ia-dropdown",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "lit": "^2.8.0 || ^3.3.2"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This version declares a lit ^2 || ^3 dual range so consumers can dedupe onto a single Lit copy (#36)